### PR TITLE
Update openapi.yaml

### DIFF
--- a/api/v1/statuspage/api/openapi.yaml
+++ b/api/v1/statuspage/api/openapi.yaml
@@ -6725,7 +6725,7 @@ components:
         page_access_group_id: page_access_group_id
         id: q84skbxr4hv3
         email: user@example.com
-        page_access_group_ids: '[]'
+        page_access_group_ids: []
       properties:
         id:
           description: Page Access User Identifier
@@ -6742,8 +6742,10 @@ components:
         page_access_group_id:
           type: string
         page_access_group_ids:
-          example: '[]'
-          type: string
+          example: []
+          items:
+            type: string
+          type: array
         created_at:
           format: date-time
           type: string

--- a/api/v1/statuspage/docs/PageAccessUser.md
+++ b/api/v1/statuspage/docs/PageAccessUser.md
@@ -9,7 +9,7 @@ Name | Type | Description | Notes
 **Email** | Pointer to **string** |  | [optional] 
 **ExternalLogin** | Pointer to **string** | IDP login user id. Key is typically \&quot;uid\&quot;. | [optional] 
 **PageAccessGroupId** | Pointer to **string** |  | [optional] 
-**PageAccessGroupIds** | Pointer to **string** |  | [optional] 
+**PageAccessGroupIds** | Pointer to **[]string** |  | [optional] 
 **CreatedAt** | Pointer to **time.Time** |  | [optional] 
 **UpdatedAt** | Pointer to **time.Time** |  | [optional] 
 
@@ -159,20 +159,20 @@ HasPageAccessGroupId returns a boolean if a field has been set.
 
 ### GetPageAccessGroupIds
 
-`func (o *PageAccessUser) GetPageAccessGroupIds() string`
+`func (o *PageAccessUser) GetPageAccessGroupIds() []string`
 
 GetPageAccessGroupIds returns the PageAccessGroupIds field if non-nil, zero value otherwise.
 
 ### GetPageAccessGroupIdsOk
 
-`func (o *PageAccessUser) GetPageAccessGroupIdsOk() (*string, bool)`
+`func (o *PageAccessUser) GetPageAccessGroupIdsOk() (*[]string, bool)`
 
 GetPageAccessGroupIdsOk returns a tuple with the PageAccessGroupIds field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPageAccessGroupIds
 
-`func (o *PageAccessUser) SetPageAccessGroupIds(v string)`
+`func (o *PageAccessUser) SetPageAccessGroupIds(v []string)`
 
 SetPageAccessGroupIds sets PageAccessGroupIds field to given value.
 

--- a/api/v1/statuspage/model_page_access_user.go
+++ b/api/v1/statuspage/model_page_access_user.go
@@ -24,7 +24,7 @@ type PageAccessUser struct {
 	// IDP login user id. Key is typically \"uid\".
 	ExternalLogin *string `json:"external_login,omitempty"`
 	PageAccessGroupId *string `json:"page_access_group_id,omitempty"`
-	PageAccessGroupIds *string `json:"page_access_group_ids,omitempty"`
+	PageAccessGroupIds *[]string `json:"page_access_group_ids,omitempty"`
 	CreatedAt *time.Time `json:"created_at,omitempty"`
 	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 }
@@ -207,9 +207,9 @@ func (o *PageAccessUser) SetPageAccessGroupId(v string) {
 }
 
 // GetPageAccessGroupIds returns the PageAccessGroupIds field value if set, zero value otherwise.
-func (o *PageAccessUser) GetPageAccessGroupIds() string {
+func (o *PageAccessUser) GetPageAccessGroupIds() []string {
 	if o == nil || o.PageAccessGroupIds == nil {
-		var ret string
+		var ret []string
 		return ret
 	}
 	return *o.PageAccessGroupIds
@@ -217,7 +217,7 @@ func (o *PageAccessUser) GetPageAccessGroupIds() string {
 
 // GetPageAccessGroupIdsOk returns a tuple with the PageAccessGroupIds field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *PageAccessUser) GetPageAccessGroupIdsOk() (*string, bool) {
+func (o *PageAccessUser) GetPageAccessGroupIdsOk() (*[]string, bool) {
 	if o == nil || o.PageAccessGroupIds == nil {
 		return nil, false
 	}
@@ -233,8 +233,8 @@ func (o *PageAccessUser) HasPageAccessGroupIds() bool {
 	return false
 }
 
-// SetPageAccessGroupIds gets a reference to the given string and assigns it to the PageAccessGroupIds field.
-func (o *PageAccessUser) SetPageAccessGroupIds(v string) {
+// SetPageAccessGroupIds gets a reference to the given []string and assigns it to the PageAccessGroupIds field.
+func (o *PageAccessUser) SetPageAccessGroupIds(v []string) {
 	o.PageAccessGroupIds = &v
 }
 


### PR DESCRIPTION
Changing the model for page_access_users to correctly reflect an array
of strings coming back for `page_access_group_ids`

I need this for a change to the terraform provider to actually handle
page access users and page access groups.  Perhaps you'll find it useful
too.

I didn't update to the latest swagger.json/openapi.yaml because there
appears to be some redaction at the very least and the upstream
swagger.json is still wrong about the output from this api call.